### PR TITLE
prof_log: delay calling atexit

### DIFF
--- a/src/prof.c
+++ b/src/prof.c
@@ -86,6 +86,8 @@ enum prof_logging_state_e {
  */
 prof_logging_state_t prof_logging_state = prof_logging_state_stopped;
 
+bool prof_logging_final_hook_registerred = false;
+
 #ifdef JEMALLOC_JET
 static bool prof_log_dummy = false;
 #endif
@@ -2513,6 +2515,13 @@ prof_log_dummy_set(bool new_value) {
 }
 #endif
 
+/* Used as an atexit function to stop logging on exit. */
+static void
+prof_log_stop_final(void) {
+	tsd_t *tsd = tsd_fetch();
+	prof_log_stop(tsd_tsdn(tsd));
+}
+
 bool
 prof_log_start(tsdn_t *tsdn, const char *filename) {
 	if (!opt_prof || !prof_booted) {
@@ -2542,17 +2551,22 @@ prof_log_start(tsdn_t *tsdn, const char *filename) {
 	if (!ret) {
 		nstime_update(&log_start_timestamp);
 	}
+	
+	if (!prof_logging_final_hook_registerred) {
+		if (atexit(prof_log_stop_final) != 0) {
+			malloc_write("<jemalloc>: Error in atexit() "
+				     "for logging\n");
+			if (opt_abort) {
+				abort();
+			}
+		} else {
+			prof_logging_final_hook_registerred = true;
+		}
+	}
 
 	malloc_mutex_unlock(tsdn, &log_mtx);
 
 	return ret;
-}
-
-/* Used as an atexit function to stop logging on exit. */
-static void
-prof_log_stop_final(void) {
-	tsd_t *tsd = tsd_fetch();
-	prof_log_stop(tsd_tsdn(tsd));
 }
 
 struct prof_emitter_cb_arg_s {
@@ -3017,14 +3031,6 @@ prof_boot2(tsd_t *tsd) {
 
 		if (opt_prof_log) {
 			prof_log_start(tsd_tsdn(tsd), NULL);
-		}
-
-		if (atexit(prof_log_stop_final) != 0) {
-			malloc_write("<jemalloc>: Error in atexit() "
-				     "for logging\n");
-			if (opt_abort) {
-				abort();
-			}
 		}
 
 		if (malloc_mutex_init(&log_mtx, "prof_log",

--- a/src/prof.c
+++ b/src/prof.c
@@ -86,7 +86,7 @@ enum prof_logging_state_e {
  */
 prof_logging_state_t prof_logging_state = prof_logging_state_stopped;
 
-bool prof_logging_final_hook_registerred = false;
+bool prof_logging_final_hook_registered = false;
 
 #ifdef JEMALLOC_JET
 static bool prof_log_dummy = false;
@@ -2552,7 +2552,7 @@ prof_log_start(tsdn_t *tsdn, const char *filename) {
 		nstime_update(&log_start_timestamp);
 	}
 	
-	if (!prof_logging_final_hook_registerred) {
+	if (!prof_logging_final_hook_registered) {
 		if (atexit(prof_log_stop_final) != 0) {
 			malloc_write("<jemalloc>: Error in atexit() "
 				     "for logging\n");
@@ -2560,7 +2560,7 @@ prof_log_start(tsdn_t *tsdn, const char *filename) {
 				abort();
 			}
 		} else {
-			prof_logging_final_hook_registerred = true;
+			prof_logging_final_hook_registered = true;
 		}
 	}
 


### PR DESCRIPTION
atexit can allocate on some platform, which will lead to deadlock. So
this PR delays calling atexit until it's really necessary.
